### PR TITLE
Adding support for 2FA and dependencies updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+import sys
+import os
+
 from src.executor import executor
 from src.api import server
 from src.config import config
@@ -5,6 +8,10 @@ from src.detect import detect
 from src.log import logger
 
 if __name__ == '__main__':
+    for arg in sys.argv[1:]:
+        if '=' in arg:
+            key, value = arg.split('=', 1)
+            os.environ[key.strip()] = value.strip().rstrip('/')
     config.init_config()
     logger.init_log()
     detect.init_model()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-Pillow==9.4.0
+Pillow>=10.0.0
 requests==2.28.2
 numpy>=1.18.5
+setuptools<71

--- a/src/api/api.py
+++ b/src/api/api.py
@@ -31,7 +31,8 @@ def get_token():
     global cookie
     global token
     global headers
-    url = f'{base_url}/webapi/auth.cgi?api=SYNO.API.Auth&version=3&method=login&account={username}&passwd={pwd}&format=cookie&enable_syno_token=yes'
+    otp_code = os.environ.get('otp', '')
+    url = f'{base_url}/webapi/auth.cgi?api=SYNO.API.Auth&version=6&method=login&account={username}&passwd={pwd}&format=cookie&enable_syno_token=yes&otp_code={otp_code}'
     response = requests.get(url)
     try:
         data = json.loads(response.content)
@@ -43,6 +44,20 @@ def get_token():
                 'X-SYNO-TOKEN': token,
             }
         else:
+            code = str(data.get('error', {}).get('code', ''))
+            if code == '403':
+                otp_code = input('Enter 2FA OTP code: ').strip()
+                url = f'{base_url}/webapi/auth.cgi?api=SYNO.API.Auth&version=6&method=login&account={username}&passwd={pwd}&format=cookie&enable_syno_token=yes&otp_code={otp_code}'
+                response = requests.get(url)
+                data = json.loads(response.content)
+                if data['success']:
+                    cookie = response.headers.get('Set-Cookie')
+                    token = data['data']['synotoken']
+                    headers = {
+                        'Cookie': cookie,
+                        'X-SYNO-TOKEN': token,
+                    }
+                    return
             error_msg = get_error_message(data)
             logger.error(error_msg)
     except Exception as e:

--- a/yolov5/hubconf.py
+++ b/yolov5/hubconf.py
@@ -62,7 +62,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
             cfg = list((Path(__file__).parent / 'models').rglob(f'{path.stem}.yaml'))[0]  # model.yaml path
             model = DetectionModel(cfg, channels, classes)  # create model
             if pretrained:
-                ckpt = torch.load(attempt_download(path), map_location=device)  # load
+                ckpt = torch.load(attempt_download(path), map_location=device, weights_only=False)  # load
                 csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32
                 csd = intersect_dicts(csd, model.state_dict(), exclude=['anchors'])  # intersect
                 model.load_state_dict(csd, strict=False)  # load

--- a/yolov5/models/experimental.py
+++ b/yolov5/models/experimental.py
@@ -76,7 +76,7 @@ def attempt_load(weights, device=None, inplace=True, fuse=True):
 
     model = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
-        ckpt = torch.load(attempt_download(w), map_location='cpu')  # load
+        ckpt = torch.load(attempt_download(w), map_location='cpu', weights_only=False)  # load
         ckpt = (ckpt.get('ema') or ckpt['model']).to(device).float()  # FP32 model
 
         # Model compatibility updates


### PR DESCRIPTION
Problem

  Four separate compatibility issues broke the application after dependency and environment upgrades:

  1. No module named 'pkg_resources' — Starting with setuptools 71, pkg_resources is no longer exposed as a top-level importable
  module. The project's requirements.txt did not pin setuptools, so a fresh install on a machine with setuptools 71+ would fail
  immediately at startup.
  2. Weights only load failed (YOLOv5 model loading) — PyTorch 2.6 changed the default value of weights_only in torch.load from False
   to True. YOLOv5 checkpoint files contain arbitrary Python objects that cannot be deserialized in weights-only mode, so any
  environment running PyTorch 2.6+ would fail to load the detection model.
  3. KeyError: 'user' on Windows CMD — The application reads credentials from environment variables. On Linux/macOS, users can pass
  these inline (user=x python main.py), but Windows CMD does not support inline env var assignment. Users were passing arguments as
  python main.py user=x pwd=y, which Python receives as sys.argv entries rather than environment variables, causing a KeyError on
  startup.
  4. 403 authentication error (2FA) — The Synology NAS has two-factor authentication enabled. The original login code targeted
  SYNO.API.Auth version 3, which does not support OTP codes. Any NAS with 2FA enforced would always return error code 403 and fail to
   authenticate.

  Solution

  1. Added setuptools to requirements.txt to ensure pkg_resources remains available.
  2. Explicitly passed weights_only=False to both torch.load call sites inside the vendored YOLOv5 code to restore pre-2.6 behavior.
  3. Added a sys.argv parsing loop in main.py that converts key=value CLI args into environment variables, enabling Windows CMD
  usage.
  4. Upgraded the Synology auth URL to SYNO.API.Auth version 6 with OTP support. The login flow now accepts otp from CLI args or
  interactively prompts the user when a 403 is returned.

  Changes

  - main.py — Added sys.argv loop before initialization that parses key=value arguments into environment variables. Also strips
  trailing / from values to handle copy-paste mistakes in URLs.
  - src/api/api.py — Upgraded auth API version from 3 to 6; added otp_code in the login URL; added error 403 handling that prompts
  for OTP and retries authentication.
  - yolov5/hubconf.py — Added weights_only=False to the torch.load call to restore compatibility with PyTorch 2.6+.
  - yolov5/models/experimental.py — Added weights_only=False to the torch.load call to restore compatibility with PyTorch 2.6+.
  - requirements.txt — Added setuptools to ensure pkg_resources remains available on setuptools 71+.

  Testing

  - pkg_resources: Fresh virtual environment install from requirements.txt — verify no No module named 'pkg_resources' error.
  - YOLOv5 model loading: Run with PyTorch 2.6+ and confirm the model loads without a weights_only error.
  - Windows CMD args: Run python main.py user=<name> pwd=<password> ip=<host> on Windows CMD and verify no KeyError.
  - 2FA pre-seeded OTP: Pass otp=<code> on the command line and verify login succeeds without an interactive prompt.
  - 2FA interactive OTP: Run without otp against a 2FA-enabled NAS and verify the app prompts Enter 2FA OTP code, accepts the code and authenticates successfully.
  - Non-2FA NAS: Verify a NAS without 2FA still authenticates correctly with auth API version 6.